### PR TITLE
use core's helpers for managing the TemplateEnvironment and template functions

### DIFF
--- a/custom_components/template_unit_helper/__init__.py
+++ b/custom_components/template_unit_helper/__init__.py
@@ -1,90 +1,28 @@
 """Helpers and custom filters for template unit conversions in Home Assistant."""
 
+import logging
+
 from homeassistant.components.light import PLATFORM_SCHEMA as LIGHT_PLATFORM_SCHEMA
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import template
+from homeassistant.helpers.template.extensions.base import (
+    BaseTemplateExtension,
+    TemplateFunction,
+)
 from homeassistant.helpers.typing import ConfigType
 
 from . import helpers
 
 DOMAIN = "template_unit_helper"
 
-# Initialization inspired by https://github.com/zvldz/ha_custom_filters
-
-_TemplateEnvironment = template.TemplateEnvironment
-
 # Validation of the user's configuration
 PLATFORM_SCHEMA = LIGHT_PLATFORM_SCHEMA.extend({})
 
-custom_filters = [
-    helpers.from_unit,
-    helpers.to_unit,
-    helpers.with_unit,
-    helpers.without_unit,
-]
-
-"""
-async def async_setup(hass: HomeAssistant, config):
-    # Register as global functions
-    # template.global_functions["to_unit"] = lambda value, target: helpers.to_unit(value, target)
-    # template.global_functions["convert"] = lambda value, from_u, to_u: helpers.convert(value, from_u, to_u)
-    # template.global_functions["quantity"] = lambda value: helpers.quantity(value)
-    template.global_functions["to_unit"] = helpers.to_unit
-    template.global_functions["convert"] = helpers.convert
-    template.global_functions["quantity"] = helpers.quantity
-
-    # Register as filters (pipe support)
-    template.Template.environment.filters["to_unit"] = helpers.to_unit
-    template.Template.environment.filters["convert"] = helpers.convert
-    template.Template.environment.filters["quantity"] = helpers.quantity
-
-    template.TemplateEnvironment.hass_filter("reverse", my_reverse_filter)
-    template.TemplateEnvironment.
-    return True
-"""
-
-
-def add_custom_filter_function(custom_filter, *environments):
-    """Add a function as global function and filter."""
-    name = (
-        custom_filter["name"]
-        if isinstance(custom_filter, dict)
-        else custom_filter.__name__
-    )
-    function = (
-        custom_filter["function"] if isinstance(custom_filter, dict) else custom_filter
-    )
-
-    def _make_wrapper(func, env):
-        def _wrapper(*args, **kwargs):
-            return func(env.hass, *args, **kwargs)
-
-        return _wrapper
-
-    for env in environments:
-        env.globals[name] = env.filters[name] = _make_wrapper(function, env)
-
-
-def init(*args):
-    """Initialize filters."""
-    env = _TemplateEnvironment(*args)
-
-    for f in custom_filters:
-        add_custom_filter_function(f, env)
-
-    return env
-
+logger = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Template Unit Helper from a config entry."""
-    # Get a template instance to access the template environment
-    tpl = template.Template("", hass)
-
-    # Register all custom filters
-    for f in custom_filters:
-        add_custom_filter_function(f, tpl._env)  # noqa: SLF001
-
     return True
 
 
@@ -97,18 +35,23 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     """Set up Template Unit Helper (legacy support)."""
-    # This is kept for backward compatibility but should not be needed
-    # when using config flow
+    # Depending on load order, a TemplateEnvironment may be created & cached before the hook below
+    # is executed, thus missing our extension.  Nuke the cache just in case.
+    for key in (template._ENVIRONMENT, template._ENVIRONMENT_LIMITED, template._ENVIRONMENT_STRICT):
+        if (env := hass.data.pop(key, None)) is not None:
+            logger.warning(f"removed cached TemplateEnvironment for {key}")
+            # Ensure any templates holding onto the cached env get the extension.
+            env.add_extension(helpers.UnitHelperTemplateExtension)
     return True
 
 
-def main():
-    """Executed during loading of integration."""
-    # Old - not needed anymore: template.TemplateEnvironment = init
-    # Explicitly instantiate a raw environment passing None for hass    
-    env = _TemplateEnvironment(None)
-    for f in custom_filters:
-        add_custom_filter_function(f, env)  # noqa: SLF001
+_TE = template.TemplateEnvironment
 
+class UnitHelperTemplateEnvironment(_TE):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_extension(helpers.UnitHelperTemplateExtension)
 
-main()
+# This needs to happen before async_setup() etc, so that the environment is hooked before
+# instances are cached in core. But also see cache management above.
+template.TemplateEnvironment = UnitHelperTemplateEnvironment

--- a/custom_components/template_unit_helper/helpers.py
+++ b/custom_components/template_unit_helper/helpers.py
@@ -8,175 +8,218 @@ numeric values, and [value, unit] arrays.
 import pint
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.template import TemplateState
+from homeassistant.helpers.template import TemplateState, TemplateEnvironment
+from homeassistant.helpers.template.extensions.base import (
+    BaseTemplateExtension,
+    TemplateFunction,
+)
 
 ureg = pint.UnitRegistry()
 Q_ = ureg.Quantity
 NO_DIMENSION = ureg.Unit('dimensionless')
 
-def from_unit(
-    hass: HomeAssistant,
-    expr,
-    source_unit: str | None = None,
-    target_unit: str | None = None,
-):
-    """Convert numeric value between units."""
-    return to_unit(hass, expr, target_unit, source_unit)
+class UnitHelperTemplateExtension(BaseTemplateExtension):
+
+    def __init__(self, environment: TemplateEnvironment) -> None:
+        """Initialize the area extension."""
+        super().__init__(
+            environment,
+            functions=[
+                TemplateFunction(
+                    "from_unit",
+                    self.from_unit,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
+                TemplateFunction(
+                    "to_unit",
+                    self.to_unit,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
+                TemplateFunction(
+                    "with_unit",
+                    self.with_unit,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
+                TemplateFunction(
+                    "without_unit",
+                    self.without_unit,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
+            ],
+        )
 
 
-def to_unit(
-    hass: HomeAssistant,
-    expr,
-    target_unit: str | None = None,
-    source_unit: str | None = None,
-):
-    """Convert a value to a target unit."""
-
-    q = with_unit(hass, expr, source_unit)
-    if target_unit is None or target_unit == source_unit:
-        return q
-    
-    ex = None
-    try:
-        return q.to(target_unit).magnitude
-    except Exception as e:  # noqa: BLE001
-        ex = e
-        if str(q.u).startswith("delta_"):
-            try:
-                # Try to add zero delta value to transform to "normal" unit
-                return (
-                    (q + with_unit(hass, 0, str(q.u)[6:]))
-                    .to(target_unit)
-                    .magnitude
-                )
-            except Exception:  # noqa: BLE001
-                pass
-    raise ValueError(
-        f"Conversion failed with expr={q:~#P}, target_unit={target_unit!r}: {ex}"
-    ) from ex
+    def from_unit(
+        self,
+        expr,
+        source_unit: str | None = None,
+        target_unit: str | None = None,
+    ):
+        """Convert numeric value between units."""
+        return self.to_unit(expr, target_unit, source_unit)
 
 
-def without_unit(hass: HomeAssistant, expr):
-    """Return the raw number without any conversion."""
-    if isinstance(expr, (list, tuple)) and len(expr) == 2:
-        value, _ = expr
-    else:
-        value = expr
-    if isinstance(value, Q_):
-        return value.magnitude
-    if isinstance(value, TemplateState):
-        return value.state
-    try:
-        return float(str(value))
-    except Exception:  # noqa: BLE001
-        pass
-    return value
+    def to_unit(
+        self,
+        expr,
+        target_unit: str | None = None,
+        source_unit: str | None = None,
+    ):
+        """Convert a value to a target unit."""
 
-def try_float(s):
-    try:
-        return float(s)
-    except:
-        return s
+        q = self.with_unit(expr, source_unit)
+        if target_unit is None or target_unit == source_unit:
+            return q
 
-def with_unit(hass: HomeAssistant, expr, target_unit: str | None = None):
-    """Return a Pint Quantity object.
-
-    Supports:
-    - numeric or string values
-    - TemplateState objects (states.sensor.xxx)
-    - 2-element arrays [value, unit]
-    """
-    value = None
-    value_unit = None
-    entity = None
-
-    # if expression is a quantity object itself
-    # then simply return it
-    if isinstance(expr, Q_):
-        entity = expr
-        value = entity.magnitude
-        value_unit = str(entity.u)
-    # Check for 2-element array - [value, unit]
-    elif isinstance(expr, (list, tuple)) and len(expr) == 2:
-        value, value_unit = expr
+        ex = None
         try:
-            entity = Q_(try_float(value), value_unit)
-            if entity.u == NO_DIMENSION:
+            return q.to(target_unit).magnitude
+        except Exception as e:  # noqa: BLE001
+            ex = e
+            if str(q.u).startswith("delta_"):
+                try:
+                    # Try to add zero delta value to transform to "normal" unit
+                    return (
+                        (q + self.with_unit(0, str(q.u)[6:]))
+                        .to(target_unit)
+                        .magnitude
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+        raise ValueError(
+            f"Conversion failed with expr={q:~#P}, target_unit={target_unit!r}: {ex}"
+        ) from ex
+
+
+    def without_unit(self, expr):
+        """Return the raw number without any conversion."""
+        if isinstance(expr, (list, tuple)) and len(expr) == 2:
+            value, _ = expr
+        else:
+            value = expr
+        if isinstance(value, Q_):
+            return value.magnitude
+        if isinstance(value, TemplateState):
+            return value.state
+        try:
+            return float(str(value))
+        except Exception:  # noqa: BLE001
+            pass
+        return value
+
+    def try_float(self, s):
+        try:
+            return float(s)
+        except:
+            return s
+
+    def with_unit(self, expr, target_unit: str | None = None):
+        """Return a Pint Quantity object.
+
+        Supports:
+        - numeric or string values
+        - TemplateState objects (states.sensor.xxx)
+        - 2-element arrays [value, unit]
+        """
+        value = None
+        value_unit = None
+        entity = None
+
+        # if expression is a quantity object itself
+        # then simply return it
+        if isinstance(expr, Q_):
+            entity = expr
+            value = entity.magnitude
+            value_unit = str(entity.u)
+        # Check for 2-element array - [value, unit]
+        elif isinstance(expr, (list, tuple)) and len(expr) == 2:
+            value, value_unit = expr
+            try:
+                entity = Q_(self.try_float(value), value_unit)
+                if entity.u == NO_DIMENSION:
+                    entity = None
+            except err as Exception:
+                raise ValueError(
+                    f"Cannot convert expression '{value!r}' and unit '{value_unit!r}' to quantity: : {err}"
+                ) from err
+
+        else:
+            # If expression is text, then check
+            # if the text is a state name
+            if isinstance(expr, str):
+                if expr.startswith("states."):
+                    state = self.hass.states.get(expr[7:])
+                    if state is None:
+                        raise ValueError(f"State {expr} not found")
+                    expr = TemplateState(self.hass, state)
+            # Check for TemplateState
+            if isinstance(expr, TemplateState):
+                value_unit = expr.attributes.get("unit_of_measurement")
+                value = expr.state
+            else:
+                value = expr
+
+        # End of parsing `expr` - from here onwards we
+        # deal with `value`, optional `value_unit` and optional `entity`
+
+        if entity is None:
+            # try to convert to quantity
+            try:
+                if value_unit is None:
+                    entity = Q_(self.try_float(value))
+                else:
+                    entity = Q_(self.try_float(value), value_unit)
+                if entity.u == NO_DIMENSION:
+                    entity = None
+            except:
                 entity = None
-        except err as Exception:
+            if entity is not None:
+                value_unit = str(entity.u)
+                value = entity.magnitude
+            elif target_unit is None:
+                raise ValueError(
+                    f"Cannot convert '{expr!r}' without a unit"
+                )
+            else:
+                value_unit = target_unit
+
+        if value_unit is not None and target_unit is not None:
+            try:
+                u1 = pint.Unit(value_unit)
+            except:
+                raise ValueError(f"Unknown unit {value_unit!r}")
+            try:
+                u2 = pint.Unit(target_unit)
+            except:
+                raise ValueError(f"Unknown unit {target_unit!r}")
+
+            if u1 != u2:
+                raise ValueError(
+                    f"Unit '{value_unit!r}' of expression does not match expected unit '{target_unit!r}'"
+                )
+
+        if entity is not None:
+            return entity
+
+        # once this point is reached we can safely assume that
+        # we have to deal with `value` being a number and `target_unit`
+        # being the unit
+        try:
+            return Q_(self.try_float(value), value_unit)
+        except (
+            ValueError,
+            TypeError,
+            pint.UndefinedUnitError,
+            pint.DimensionalityError,
+        ) as err:
             raise ValueError(
                 f"Cannot convert expression '{value!r}' and unit '{value_unit!r}' to quantity: : {err}"
             ) from err
-
-    else:
-        # If expression is text, then check
-        # if the text is a state name
-        if isinstance(expr, str):
-            if expr.startswith("states."):
-                state = hass.states.get(expr[7:])
-                if state is None:
-                    raise ValueError(f"State {expr} not found")
-                expr = TemplateState(hass, state)
-        # Check for TemplateState
-        if isinstance(expr, TemplateState):
-            value_unit = expr.attributes.get("unit_of_measurement")
-            value = expr.state
-        else:
-            value = expr
-
-    # End of parsing `expr` - from here onwards we
-    # deal with `value`, optional `value_unit` and optional `entity`
-
-    if entity is None:
-        # try to convert to quantity
-        try:
-            if value_unit is None:
-                entity = Q_(try_float(value))
-            else:
-                entity = Q_(try_float(value), value_unit)
-            if entity.u == NO_DIMENSION:
-                entity = None
-        except:
-            entity = None            
-        if entity is not None:
-            value_unit = str(entity.u)
-            value = entity.magnitude
-        elif target_unit is None:
-            raise ValueError(
-                f"Cannot convert '{expr!r}' without a unit"
-            )
-        else:
-            value_unit = target_unit
-
-    if value_unit is not None and target_unit is not None:
-        try:
-            u1 = pint.Unit(value_unit)
-        except:
-            raise ValueError(f"Unknown unit {value_unit!r}")
-        try:        
-            u2 = pint.Unit(target_unit)
-        except:
-            raise ValueError(f"Unknown unit {target_unit!r}")
-
-        if u1 != u2:
-            raise ValueError(
-                f"Unit '{value_unit!r}' of expression does not match expected unit '{target_unit!r}'"
-            )
-
-    if entity is not None:
-        return entity
-
-    # once this point is reached we can safely assume that
-    # we have to deal with `value` being a number and `target_unit`
-    # being the unit
-    try:
-        return Q_(try_float(value), value_unit)
-    except (
-        ValueError,
-        TypeError,
-        pint.UndefinedUnitError,
-        pint.DimensionalityError,
-    ) as err:
-        raise ValueError(
-            f"Cannot convert expression '{value!r}' and unit '{value_unit!r}' to quantity: : {err}"
-        ) from err


### PR DESCRIPTION
This refactor uses the [classes `BaseTemplateExtension` and `TemplateFunction` provided by core][core] to add template functions in the same manner as core itself. This avoids duplicating the logic for injecting the functions/filters. I refactored the helpers to use a similar class-based style as core's template extensions; the logic itself is unchanged.

The caching for TemplateEnvironment in core is here: https://github.com/home-assistant/core/blob/e5f26210686b9e33a9c4ab0c18d999845c089884/homeassistant/helpers/template/__init__.py#L338

This also fixes #8 .

I tested this on my HA install running `2026.7.4`.

[core]: https://github.com/home-assistant/core/blob/e5f26210686b9e33a9c4ab0c18d999845c089884/homeassistant/helpers/template/extensions/base.py