### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Home Assistant **HACS integration** that provides **unit conversion and quanti
 
 ### Via HACS
 This custom template is compatible with [HACS](https://hacs.xyz/), which means that you can easily download and manage updates for it. Custom templates are available for download in HACS 2.0 and up, and on earlier versions in case experimental features are enabled. When you are on HACS 2.0 or higher or experimental features are enabled you can click the button below to add it to your HACS installation:
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ultravail&repository=homeassistant-template-unit-helper&category=template)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ultravail&repository=homeassistant-template-unit-helper&category=integration)
 
 ### Via HACS with custom repository
 For a manual install you need to add this repository as custom repository:

--- a/README.md
+++ b/README.md
@@ -30,13 +30,21 @@ For a manual install you need to add this repository as custom repository:
    ```
    with Type: **Integration**
  
-3. Install `Template Unit Helper` and restart Home Assistant.
-4. Go to **Settings → Devices & Services → Add Integration** and search for "Template Unit Helper" to complete the setup.
+3. Install `Template Unit Helper`.
+4. Edit your `configuration.yaml`, and add the following on its own line:
+   ```yaml
+   template_unit_helper:
+   ```
+5. Restart Home Assistant.
 
 ### Manual install
 1. Copy the `custom_components/template_unit_helper` of this repository to the `custom_components` directory of your HomeAssistant installation.
-2. Restart Home Assistant.
-3. Go to **Settings → Devices & Services → Add Integration** and search for "Template Unit Helper" to complete the setup.
+2. Edit your `configuration.yaml`, and add the following on its own line:
+   ```yaml
+   template_unit_helper:
+   ```
+3. Restart Home Assistant.
+
 
 ## Usage in Templates
 


### PR DESCRIPTION
Updated HACS integration link in README.md to use the correct `category` arg, and reference configuration.yaml since the integration can't be set up from Settings > Devices.

Fixes #1 