### PR TITLE
Fix logging in async_setup

### DIFF
--- a/custom_components/template_unit_helper/__init__.py
+++ b/custom_components/template_unit_helper/__init__.py
@@ -39,7 +39,7 @@ async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     # is executed, thus missing our extension.  Nuke the cache just in case.
     for key in (template._ENVIRONMENT, template._ENVIRONMENT_LIMITED, template._ENVIRONMENT_STRICT):
         if (env := hass.data.pop(key, None)) is not None:
-            logger.warning(f"removed cached TemplateEnvironment for {key}")
+            logger.info(f"removed cached TemplateEnvironment for {key}")
             # Ensure any templates holding onto the cached env get the extension.
             env.add_extension(helpers.UnitHelperTemplateExtension)
     return True


### PR DESCRIPTION
async_setup() logs a warning when removing a cached TemplateEnvironment, but this is not a problem or possible problem; the message is present to help debugging by distinguishing the TemplateEnvironment instances before and after this integration is set up.

Since this is a low-volume message, favor info() over debug() so that it is available without the extra step of enabling debug logs.

Fixes #12.